### PR TITLE
Support specifying I2C pins for STM

### DIFF
--- a/src/FT6336U.cpp
+++ b/src/FT6336U.cpp
@@ -13,7 +13,7 @@
 FT6336U::FT6336U(uint8_t rst_n, uint8_t int_n) 
 : rst_n(rst_n), int_n(int_n) {
 }
-#if defined(ESP32) || defined(ESP8266)
+#if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_STM32)
 FT6336U::FT6336U(int8_t sda, int8_t scl, uint8_t rst_n, uint8_t int_n) 
 : sda(sda), scl(scl), rst_n(rst_n), int_n(int_n)  {
 }
@@ -24,7 +24,7 @@ FT6336U::~FT6336U() {
 
 void FT6336U::begin(void) {
     // Initialize I2C
-#if defined(ESP32) || defined(ESP8266)
+#if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_STM32)
     if(sda != -1 && scl != -1) {
         Wire.begin(sda, scl); 
     }

--- a/src/FT6336U.h
+++ b/src/FT6336U.h
@@ -125,7 +125,7 @@ class FT6336U
 {
 public: 
     FT6336U(uint8_t rst_n, uint8_t int_n); 
-#if defined(ESP32) || defined(ESP8266)
+#if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_STM32)
     FT6336U(int8_t sda, int8_t scl, uint8_t rst_n, uint8_t int_n); 
 #endif
     virtual ~FT6336U(); 


### PR DESCRIPTION
Similar to how Wire.begin can take SDA and SCL for ESP32. This PR allows you to specify the SDA and SCL pins for STM microcontrollers, which is also supported.